### PR TITLE
Rename references to kinvolk org to flatcar-linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine
 ENV CGO_ENABLED=0
-WORKDIR $GOPATH/src/github.com/kinvolk/container-linux-config-transpiler
+WORKDIR $GOPATH/src/github.com/flatcar-linux/container-linux-config-transpiler
 COPY . .
 RUN apk update && apk add --virtual .build-deps bash git make \
     && make \

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 VERSION=$(shell git describe --dirty)
-REPO=github.com/kinvolk/container-linux-config-transpiler
+REPO=github.com/flatcar-linux/container-linux-config-transpiler
 LD_FLAGS="-w -X $(REPO)/internal/version.Raw=$(VERSION)"
 
 GO_SOURCES=$(shell find . -name "*.go")

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a more in-depth view of ct and why it exists, take a look at the [Overview][
 Please use the [bug tracker][issues] to report bugs.
 
 [ignition]: https://github.com/coreos/ignition
-[issues]: https://github.com/kinvolk/flatcar/issues
+[issues]: https://github.com/flatcar-linux/flatcar/issues
 [overview]: doc/overview.md
 [get-started]: doc/getting-started.md
 [config]: doc/configuration.md
@@ -54,7 +54,7 @@ ARCH=x86_64
 OS=unknown-linux-gnu # Linux
 
 # Specify download URL
-DOWNLOAD_URL=https://github.com/kinvolk/container-linux-config-transpiler/releases/download
+DOWNLOAD_URL=https://github.com/flatcar-linux/container-linux-config-transpiler/releases/download
 
 # Remove previous downloads
 rm -f /tmp/ct-${CT_VER}-${ARCH}-${OS} /tmp/ct-${CT_VER}-${ARCH}-${OS}.asc /tmp/coreos-app-signing-pubkey.gpg
@@ -72,14 +72,14 @@ curl -L ${DOWNLOAD_URL}/${CT_VER}/ct-${CT_VER}-${ARCH}-${OS}.asc -o /tmp/ct-${CT
 gpg2 --verify /tmp/ct-${CT_VER}-${ARCH}-${OS}.asc /tmp/ct-${CT_VER}-${ARCH}-${OS}
 ```
 
-[releases]: https://github.com/kinvolk/container-linux-config-transpiler/releases
+[releases]: https://github.com/flatcar-linux/container-linux-config-transpiler/releases
 
 ### Building from source
 
 To build from source you'll need to have the go compiler installed on your system.
 
 ```shell
-git clone --branch v0.8.0 https://github.com/kinvolk/container-linux-config-transpiler
+git clone --branch v0.8.0 https://github.com/flatcar-linux/container-linux-config-transpiler
 cd container-linux-config-transpiler
 make
 ```
@@ -91,5 +91,5 @@ Note: Review releases for new branch versions.
 ## Related projects
 
 - [https://github.com/coreos/ignition](https://github.com/coreos/ignition)
-- [https://github.com/kinvolk/afterburn/](https://github.com/kinvolk/afterburn)
+- [https://github.com/flatcar-linux/afterburn/](https://github.com/flatcar-linux/afterburn)
 - [https://github.com/poseidon/matchbox](https://github.com/poseidon/matchbox)

--- a/config/config.go
+++ b/config/config.go
@@ -23,9 +23,9 @@ import (
 	"github.com/coreos/ignition/config/validate/astnode"
 	"github.com/coreos/ignition/config/validate/report"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config/astyaml"
-	"github.com/kinvolk/container-linux-config-transpiler/config/platform"
-	"github.com/kinvolk/container-linux-config-transpiler/config/types"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/astyaml"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/platform"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/types"
 )
 
 // Parse will convert a byte slice containing a Container Linux Config into a

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,8 +25,8 @@ import (
 	ignTypes "github.com/coreos/ignition/config/v2_3/types"
 	"github.com/coreos/ignition/config/validate/report"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config/types"
-	"github.com/kinvolk/container-linux-config-transpiler/internal/util"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/types"
+	"github.com/flatcar-linux/container-linux-config-transpiler/internal/util"
 )
 
 func TestParse(t *testing.T) {

--- a/config/templating/templating.go
+++ b/config/templating/templating.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config/platform"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/platform"
 )
 
 var (

--- a/config/types/common.go
+++ b/config/types/common.go
@@ -23,10 +23,10 @@ import (
 	"github.com/coreos/ignition/config/validate/astnode"
 	"github.com/coreos/ignition/config/validate/report"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config/platform"
-	"github.com/kinvolk/container-linux-config-transpiler/config/templating"
-	"github.com/kinvolk/container-linux-config-transpiler/config/types/util"
-	iutil "github.com/kinvolk/container-linux-config-transpiler/internal/util"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/platform"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/templating"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/types/util"
+	iutil "github.com/flatcar-linux/container-linux-config-transpiler/internal/util"
 )
 
 var (

--- a/config/types/converter.go
+++ b/config/types/converter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/coreos/ignition/config/validate/astnode"
 	"github.com/coreos/ignition/config/validate/report"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config/astyaml"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/astyaml"
 )
 
 type converter func(in Config, ast astnode.AstNode, out ignTypes.Config, platform string) (ignTypes.Config, report.Report, astnode.AstNode)

--- a/config/types/files.go
+++ b/config/types/files.go
@@ -22,8 +22,8 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config/astyaml"
-	"github.com/kinvolk/container-linux-config-transpiler/internal/util"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/astyaml"
+	"github.com/flatcar-linux/container-linux-config-transpiler/internal/util"
 
 	ignTypes "github.com/coreos/ignition/config/v2_3/types"
 	"github.com/coreos/ignition/config/validate/astnode"

--- a/config/types/update.go
+++ b/config/types/update.go
@@ -20,7 +20,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/kinvolk/container-linux-config-transpiler/internal/util"
+	"github.com/flatcar-linux/container-linux-config-transpiler/internal/util"
 
 	ignTypes "github.com/coreos/ignition/config/v2_3/types"
 	"github.com/coreos/ignition/config/validate/astnode"

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -34,4 +34,4 @@ To see some examples for what else ct can do, head over to the [examples][3].
 [1]: configuration.md
 [2]: https://coreos.com/ignition/docs/latest/supported-platforms.html
 [3]: examples.md
-[4]: https://github.com/kinvolk/container-linux-config-transpiler/releases
+[4]: https://github.com/flatcar-linux/container-linux-config-transpiler/releases

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -6,7 +6,7 @@ The Container Linux Config is intended to be human-friendly, and is thus in YAML
 
 The resulting Ignition config is very much not intended to be human-friendly. It is an artifact produced by ct that users should simply pass along to their machines. JSON was chosen over a binary format to make the process more transparent and to allow power users to inspect/modify what ct produces, but it would have worked fine if the result from ct had not been human readable at all.
 
-[ct]: https://github.com/kinvolk/container-linux-config-transpiler/
+[ct]: https://github.com/flatcar-linux/container-linux-config-transpiler/
 [ignition]: https://github.com/coreos/ignition
 
 ## Why a two-step process?

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kinvolk/container-linux-config-transpiler
+module github.com/flatcar-linux/container-linux-config-transpiler
 
 go 1.16
 

--- a/internal/main.go
+++ b/internal/main.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config"
-	"github.com/kinvolk/container-linux-config-transpiler/config/platform"
-	"github.com/kinvolk/container-linux-config-transpiler/internal/version"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config/platform"
+	"github.com/flatcar-linux/container-linux-config-transpiler/internal/version"
 )
 
 func stderr(f string, a ...interface{}) {

--- a/internal/util/tools/docs.go
+++ b/internal/util/tools/docs.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kinvolk/container-linux-config-transpiler/config"
+	"github.com/flatcar-linux/container-linux-config-transpiler/config"
 )
 
 const (

--- a/release.sh
+++ b/release.sh
@@ -12,7 +12,7 @@ VER=$1
 }
 
 if test -n "$(git ls-files --others | \
-	grep --invert-match '\(gopath/src/github.com/kinvolk/container-linux-config-transpiler\|bin/ct\)')";
+	grep --invert-match '\(gopath/src/github.com/flatcar-linux/container-linux-config-transpiler\|bin/ct\)')";
 then
 	echo "directory has untracked files"
 	exit 1

--- a/test
+++ b/test
@@ -2,7 +2,7 @@
 
 set -eu
 
-ORG_PATH="github.com/kinvolk"
+ORG_PATH="github.com/flatcar-linux"
 REPO_PATH="${ORG_PATH}/container-linux-config-transpiler"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then


### PR DESCRIPTION
As the repository has been moved again. This is to allow importing the module using up to date path.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>

## Testing done

Only `go build` in `internal` directory.
