### PR TITLE
encode file contents as base64 when the result is smaller

### DIFF
--- a/config/types/files.go
+++ b/config/types/files.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"encoding/base64"
 	"errors"
 	"flag"
 	"fmt"
@@ -129,6 +130,19 @@ func (fc FileContents) Validate() report.Report {
 	return report.Report{}
 }
 
+func makeDataUrl(contents []byte) string {
+	opaque := "," + dataurl.Escape(contents)
+	b64 := ";base64," + base64.StdEncoding.EncodeToString(contents)
+	if len(b64) < len(opaque) {
+		opaque = b64
+	}
+	uri := (&url.URL{
+		Scheme: "data",
+		Opaque: opaque,
+	}).String()
+	return uri
+}
+
 func init() {
 	register(func(in Config, ast astnode.AstNode, out ignTypes.Config, platform string) (ignTypes.Config, report.Report, astnode.AstNode) {
 		r := report.Report{}
@@ -167,10 +181,7 @@ func init() {
 
 			if file.Contents.Inline != "" {
 				newFile.Contents = ignTypes.FileContents{
-					Source: (&url.URL{
-						Scheme: "data",
-						Opaque: "," + dataurl.EscapeString(file.Contents.Inline),
-					}).String(),
+					Source: makeDataUrl([]byte(file.Contents.Inline)),
 				}
 			}
 
@@ -203,10 +214,7 @@ func init() {
 
 				// Include the contents of the local file as if it were provided inline.
 				newFile.Contents = ignTypes.FileContents{
-					Source: (&url.URL{
-						Scheme: "data",
-						Opaque: "," + dataurl.Escape(contents),
-					}).String(),
+					Source: makeDataUrl(contents),
 				}
 			}
 

--- a/config/types/files_test.go
+++ b/config/types/files_test.go
@@ -1,0 +1,43 @@
+package types
+
+import (
+	"github.com/vincent-petithory/dataurl"
+	"strings"
+	"testing"
+)
+
+func TestDataURL(t *testing.T) {
+	testString1 := "hello world"
+	dataUrl1 := makeDataUrl([]byte(testString1))
+	decodedUrl1, err := dataurl.DecodeString(dataUrl1)
+	if err != nil {
+		t.Fatalf("DecodeString #1 failed: %v", err)
+	}
+	resultStr1 := string(decodedUrl1.Data)
+	if strings.HasPrefix(dataUrl1, "data:;base64,") {
+		t.Errorf("base64 encoding used instead of url encoding: %v", dataUrl1)
+	}
+	if resultStr1 != testString1 {
+		t.Errorf("wanted %v, got %v", testString1, resultStr1)
+	}
+
+	testString2 := `
+#!/bin/bash
+msg="hello"
+f() {
+	( echo "${msg}" ) &
+}
+f`
+	dataUrl2 := makeDataUrl([]byte(testString2))
+	if !strings.HasPrefix(dataUrl2, "data:;base64,") {
+		t.Errorf("base64 encoding missing: %v", dataUrl2)
+	}
+	decodedUrl2, err := dataurl.DecodeString(dataUrl2)
+	if err != nil {
+		t.Fatalf("DecodeString #2 failed: %v", err)
+	}
+	resultStr2 := string(decodedUrl2.Data)
+	if resultStr2 != testString2 {
+		t.Errorf("wanted %v, got %v", testString2, resultStr2)
+	}
+}


### PR DESCRIPTION
# encode file contents as base64 when the result is smaller

This is supported by ignition and dataurl since forever, but clct did not produce base64 encoded strings.

## How to use

Try encoding a binary file with clct:
```
inline: !!binary |
  <base64 here>
```
and observe the ignition json.

## Testing done

Successfully booted stable images with resulting ignition.
