### PR TITLE
config/types/etcd: add support for v3.4 and v3.5 options

### DIFF
--- a/config/types/etcd.go
+++ b/config/types/etcd.go
@@ -55,7 +55,7 @@ func (e EtcdVersion) Validate() report.Report {
 		return report.ReportFromError(EtcdVersionTooOld, report.EntryError)
 	case v.Major == 2 && v.Minor > 3:
 		fallthrough
-	case v.Major == 3 && v.Minor > 3:
+	case v.Major == 3 && v.Minor > 5:
 		return report.ReportFromError(EtcdMinorVersionTooNew, report.EntryWarning)
 	case v.Major > 3:
 		return report.ReportFromError(EtcdMajorVersionTooNew, report.EntryError)
@@ -114,8 +114,20 @@ func (etcd *Etcd) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			return err
 		}
 		etcd.Options = o
-	} else if version.Major == 3 && version.Minor >= 3 {
+	} else if version.Major == 3 && version.Minor == 3 {
 		o := Etcd3_3{}
+		if err := unmarshal(&o); err != nil {
+			return err
+		}
+		etcd.Options = o
+	} else if version.Major == 3 && version.Minor == 4 {
+		o := Etcd3_4{}
+		if err := unmarshal(&o); err != nil {
+			return err
+		}
+		etcd.Options = o
+	} else if version.Major == 3 && version.Minor >= 5 {
+		o := Etcd3_5{}
 		if err := unmarshal(&o); err != nil {
 			return err
 		}
@@ -371,6 +383,178 @@ type Etcd3_3 struct {
 	ExperimentalInitialCorruptCheck *bool   `yaml:"experimental_initial_corrupt_check" cli:"experimental-initial-corrupt-check"`
 	ExperimentalCorruptCheckTime    *string `yaml:"experimental_corrupt_check_time"    cli:"experimental-corrupt-check-time"`
 	ExperimentalEnableV2V3          *string `yaml:"experimental_enable_v2v3"           cli:"experimental-enable-v2v3"`
+}
+
+type Etcd3_4 struct {
+	Name                                    *string `yaml:"name"                                        cli:"name"`
+	DataDir                                 *string `yaml:"data_dir"                                    cli:"data-dir"`
+	WalDir                                  *string `yaml:"wal_dir"                                     cli:"wal-dir"`
+	SnapshotCount                           *int    `yaml:"snapshot_count"                              cli:"snapshot-count"`
+	HeartbeatInterval                       *int    `yaml:"heartbeat_interval"                          cli:"heartbeat-interval"`
+	ElectionTimeout                         *int    `yaml:"election_timeout"                            cli:"election-timeout"`
+	InitialElectionTickAdvance              *bool   `yaml:"initial_election_tick_advance"               cli:"initial-election-tick-advance"`
+	ListenPeerUrls                          *string `yaml:"listen_peer_urls"                            cli:"listen-peer-urls"`
+	ListenClientUrls                        *string `yaml:"listen_client_urls"                          cli:"listen-client-urls"`
+	MaxSnapshots                            *int    `yaml:"max_snapshots"                               cli:"max-snapshots"`
+	MaxWals                                 *int    `yaml:"max_wals"                                    cli:"max-wals"`
+	QuotaBackendBytes                       *int    `yaml:"quota_backend_bytes"                         cli:"quota-backend-bytes"`
+	BackendBatchInterval                    *string `yaml:"backend_batch_interval"                      cli:"backend-batch-interval"`
+	BackendBatchLimit                       *int    `yaml:"backend_batch_limit"                         cli:"backend-batch-limit"`
+	MaxTxnOps                               *int    `yaml:"max_txn_ops"                                 cli:"max-txn-ops"`
+	MaxRequestBytes                         *int    `yaml:"max_request_bytes"                           cli:"max-request-bytes"`
+	GrpcKeepaliveMinTime                    *string `yaml:"grpc_keepalive_min_time"                     cli:"grpc-keepalive-min-time"`
+	GrpcKeepaliveInterval                   *string `yaml:"grpc_keepalive_interval"                     cli:"grpc-keepalive-interval"`
+	GrpcKeepaliveTimeout                    *string `yaml:"grpc_keepalive_timeout"                      cli:"grpc-keepalive-timeout"`
+	InitialAdvertisePeerUrls                *string `yaml:"initial_advertise_peer_urls"                 cli:"initial-advertise-peer-urls"`
+	InitialCluster                          *string `yaml:"initial_cluster"                             cli:"initial-cluster"`
+	InitialClusterState                     *string `yaml:"initial_cluster_state"                       cli:"initial-cluster-state"`
+	InitialClusterToken                     *string `yaml:"initial_cluster_token"                       cli:"initial-cluster-token"`
+	AdvertiseClientUrls                     *string `yaml:"advertise_client_urls"                       cli:"advertise-client-urls"`
+	Discovery                               *string `yaml:"discovery"                                   cli:"discovery"`
+	DiscoveryFallback                       *string `yaml:"discovery_fallback"                          cli:"discovery-fallback"`
+	DiscoveryProxy                          *string `yaml:"discovery_proxy"                             cli:"discovery-proxy"`
+	DiscoverySrv                            *string `yaml:"discovery_srv"                               cli:"discovery-srv"`
+	DiscoverySrvName                        *string `yaml:"discovery_srv_name"                          cli:"discovery-srv-name"`
+	StrictReconfigCheck                     *bool   `yaml:"strict_reconfig_check"                       cli:"strict-reconfig-check"`
+	PreVote                                 *bool   `yaml:"pre_vote"                                    cli:"pre-vote"`
+	AutoCompactionRetention                 *string `yaml:"auto_compaction_retention"                   cli:"auto-compaction-retention"`
+	AutoCompactionMode                      *string `yaml:"auto_compaction_mode"                        cli:"auto-compaction-mode"`
+	EnableV2                                *bool   `yaml:"enable_v2"                                   cli:"enable-v2"`
+	CertFile                                *string `yaml:"cert_file"                                   cli:"cert-file"`
+	KeyFile                                 *string `yaml:"key_file"                                    cli:"key-file"`
+	ClientCertAuth                          *bool   `yaml:"client_cert_auth"                            cli:"client-cert-auth"`
+	ClientCrlFile                           *string `yaml:"client_crl_file"                             cli:"client-crl-file"`
+	ClientCertAllowedHostname               *string `yaml:"client_cert_allowed_hostname"                cli:"client-cert-allowed-hostname"`
+	TrustedCaFile                           *string `yaml:"trusted_ca_file"                             cli:"trusted-ca-file"`
+	AutoTls                                 *bool   `yaml:"auto_tls"                                    cli:"auto-tls"`
+	PeerCertFile                            *string `yaml:"peer_cert_file"                              cli:"peer-cert-file"`
+	PeerKeyFile                             *string `yaml:"peer_key_file"                               cli:"peer-key-file"`
+	PeerClientCertAuth                      *bool   `yaml:"peer_client_cert_auth"                       cli:"peer-client-cert-auth"`
+	PeerTrustedCaFile                       *string `yaml:"peer_trusted_ca_file"                        cli:"peer-trusted-ca-file"`
+	PeerCertAllowedCn                       *string `yaml:"peer_cert_allowed_cn"                        cli:"peer-cert-allowed-cn"`
+	PeerCertAllowedHostname                 *string `yaml:"peer_cert_allowed_hostname"                  cli:"peer-cert-allowed-hostname"`
+	PeerAutoTls                             *bool   `yaml:"peer_auto_tls"                               cli:"peer-auto-tls"`
+	PeerCrlFile                             *string `yaml:"peer_crl_file"                               cli:"peer-crl-file"`
+	CipherSuites                            *string `yaml:"cipher_suites"                               cli:"cipher-suites"`
+	Cors                                    *string `yaml:"cors"                                        cli:"cors"`
+	HostWhitelist                           *string `yaml:"host_whitelist"                              cli:"host-whitelist"`
+	AuthToken                               *string `yaml:"auth_token"                                  cli:"auth-token"`
+	BcryptCost                              *int    `yaml:"bcrypt_cost"                                 cli:"bcrypt-cost"`
+	AuthTokenTtl                            *int    `yaml:"auth_token_ttl"                              cli:"auth-token-ttl"`
+	EnablePprof                             *bool   `yaml:"enable_pprof"                                cli:"enable-pprof"`
+	Metrics                                 *string `yaml:"metrics"                                     cli:"metrics"`
+	ListenMetricsUrls                       *string `yaml:"listen_metrics_urls"                         cli:"listen-metrics-urls"`
+	Logger                                  *string `yaml:"logger"                                      cli:"logger"`
+	LogOutputs                              *string `yaml:"log_outputs"                                 cli:"log-outputs"`
+	LogLevel                                *string `yaml:"log_level"                                   cli:"log-level"`
+	Proxy                                   *string `yaml:"proxy"                                       cli:"proxy"`
+	ProxyFailureWait                        *int    `yaml:"proxy_failure_wait"                          cli:"proxy-failure-wait"`
+	ProxyRefreshInterval                    *int    `yaml:"proxy_refresh_interval"                      cli:"proxy-refresh-interval"`
+	ProxyDialTimeout                        *int    `yaml:"proxy_dial_timeout"                          cli:"proxy-dial-timeout"`
+	ProxyWriteTimeout                       *int    `yaml:"proxy_write_timeout"                         cli:"proxy-write-timeout"`
+	ProxyReadTimeout                        *int    `yaml:"proxy_read_timeout"                          cli:"proxy-read-timeout"`
+	ExperimentalInitialCorruptCheck         *bool   `yaml:"experimental_initial_corrupt_check"          cli:"experimental-initial-corrupt-check"`
+	ExperimentalCorruptCheckTime            *string `yaml:"experimental_corrupt_check_time"             cli:"experimental-corrupt-check-time"`
+	ExperimentalEnableV2V3                  *string `yaml:"experimental_enable_v2v3"                    cli:"experimental-enable-v2v3"`
+	ExperimentalBackendBboltFreelistType    *string `yaml:"experimental_backend_bbolt_freelist_type"    cli:"experimental-backend-bbolt-freelist-type"`
+	ExperimentalEnableLeaseCheckpoint       *bool   `yaml:"experimental_enable_lease_checkpoint"        cli:"experimental-enable-lease-checkpoint"`
+	ExperimentalCompactionBatchLimit        *int    `yaml:"experimental_compaction_batch_limit"         cli:"experimental-compaction-batch-limit"`
+	ExperimentalWatchProgressNotifyInterval *string `yaml:"experimental_watch_progress_notify_interval" cli:"experimental-watch-progress-notify-interval"`
+	ExperimentalWarningApplyDuration        *string `yaml:"experimental_warning_apply_duration"         cli:"experimental-warning-apply-duration"`
+	ForceNewCluster                         *bool   `yaml:"force_new_cluster"                           cli:"force-new-cluster"`
+	Debug                                   *bool   `yaml:"debug"                                       cli:"debug"`
+	LogPackageLevels                        *string `yaml:"log_package_levels"                          cli:"log-package-levels"`
+}
+
+type Etcd3_5 struct {
+	Name                                      *string `yaml:"name"                                           cli:"name"`
+	DataDir                                   *string `yaml:"data_dir"                                       cli:"data-dir"`
+	WalDir                                    *string `yaml:"wal_dir"                                        cli:"wal-dir"`
+	SnapshotCount                             *int    `yaml:"snapshot_count"                                 cli:"snapshot-count"`
+	HeartbeatInterval                         *int    `yaml:"heartbeat_interval"                             cli:"heartbeat-interval"`
+	ElectionTimeout                           *int    `yaml:"election_timeout"                               cli:"election-timeout"`
+	InitialElectionTickAdvance                *bool   `yaml:"initial_election_tick_advance"                  cli:"initial-election-tick-advance"`
+	ListenPeerUrls                            *string `yaml:"listen_peer_urls"                               cli:"listen-peer-urls"`
+	ListenClientUrls                          *string `yaml:"listen_client_urls"                             cli:"listen-client-urls"`
+	MaxSnapshots                              *int    `yaml:"max_snapshots"                                  cli:"max-snapshots"`
+	MaxWals                                   *int    `yaml:"max_wals"                                       cli:"max-wals"`
+	QuotaBackendBytes                         *int    `yaml:"quota_backend_bytes"                            cli:"quota-backend-bytes"`
+	BackendBboltFreelistType                  *string `yaml:"backend_bbolt_freelist_type"                    cli:"backend-bbolt-freelist-type"`
+	BackendBatchInterval                      *string `yaml:"backend_batch_interval"                         cli:"backend-batch-interval"`
+	BackendBatchLimit                         *int    `yaml:"backend_batch_limit"                            cli:"backend-batch-limit"`
+	MaxTxnOps                                 *int    `yaml:"max_txn_ops"                                    cli:"max-txn-ops"`
+	MaxRequestBytes                           *int    `yaml:"max_request_bytes"                              cli:"max-request-bytes"`
+	GrpcKeepaliveMinTime                      *string `yaml:"grpc_keepalive_min_time"                        cli:"grpc-keepalive-min-time"`
+	GrpcKeepaliveInterval                     *string `yaml:"grpc_keepalive_interval"                        cli:"grpc-keepalive-interval"`
+	GrpcKeepaliveTimeout                      *string `yaml:"grpc_keepalive_timeout"                         cli:"grpc-keepalive-timeout"`
+	SocketReusePort                           *bool   `yaml:"socket_reuse_port"                              cli:"socket-reuse-port"`
+	SocketReuseAddress                        *bool   `yaml:"socket_reuse_address"                           cli:"socket-reuse-address"`
+	InitialAdvertisePeerUrls                  *string `yaml:"initial_advertise_peer_urls"                    cli:"initial-advertise-peer-urls"`
+	InitialCluster                            *string `yaml:"initial_cluster"                                cli:"initial-cluster"`
+	InitialClusterState                       *string `yaml:"initial_cluster_state"                          cli:"initial-cluster-state"`
+	InitialClusterToken                       *string `yaml:"initial_cluster_token"                          cli:"initial-cluster-token"`
+	AdvertiseClientUrls                       *string `yaml:"advertise_client_urls"                          cli:"advertise-client-urls"`
+	Discovery                                 *string `yaml:"discovery"                                      cli:"discovery"`
+	DiscoveryFallback                         *string `yaml:"discovery_fallback"                             cli:"discovery-fallback"`
+	DiscoveryProxy                            *string `yaml:"discovery_proxy"                                cli:"discovery-proxy"`
+	DiscoverySrv                              *string `yaml:"discovery_srv"                                  cli:"discovery-srv"`
+	DiscoverySrvName                          *string `yaml:"discovery_srv_name"                             cli:"discovery-srv-name"`
+	StrictReconfigCheck                       *bool   `yaml:"strict_reconfig_check"                          cli:"strict-reconfig-check"`
+	PreVote                                   *bool   `yaml:"pre_vote"                                       cli:"pre-vote"`
+	AutoCompactionRetention                   *string `yaml:"auto_compaction_retention"                      cli:"auto-compaction-retention"`
+	AutoCompactionMode                        *string `yaml:"auto_compaction_mode"                           cli:"auto-compaction-mode"`
+	EnableV2                                  *bool   `yaml:"enable_v2"                                      cli:"enable-v2"`
+	V2Deprecation                             *string `yaml:"v2_deprecation"                                 cli:"v2-deprecation"`
+	CertFile                                  *string `yaml:"cert_file"                                      cli:"cert-file"`
+	KeyFile                                   *string `yaml:"key_file"                                       cli:"key-file"`
+	ClientCertAuth                            *bool   `yaml:"client_cert_auth"                               cli:"client-cert-auth"`
+	ClientCrlFile                             *string `yaml:"client_crl_file"                                cli:"client-crl-file"`
+	ClientCertAllowedHostname                 *string `yaml:"client_cert_allowed_hostname"                   cli:"client-cert-allowed-hostname"`
+	TrustedCaFile                             *string `yaml:"trusted_ca_file"                                cli:"trusted-ca-file"`
+	AutoTls                                   *bool   `yaml:"auto_tls"                                       cli:"auto-tls"`
+	PeerCertFile                              *string `yaml:"peer_cert_file"                                 cli:"peer-cert-file"`
+	PeerKeyFile                               *string `yaml:"peer_key_file"                                  cli:"peer-key-file"`
+	PeerClientCertAuth                        *bool   `yaml:"peer_client_cert_auth"                          cli:"peer-client-cert-auth"`
+	PeerTrustedCaFile                         *string `yaml:"peer_trusted_ca_file"                           cli:"peer-trusted-ca-file"`
+	PeerCertAllowedCn                         *string `yaml:"peer_cert_allowed_cn"                           cli:"peer-cert-allowed-cn"`
+	PeerCertAllowedHostname                   *string `yaml:"peer_cert_allowed_hostname"                     cli:"peer-cert-allowed-hostname"`
+	PeerAutoTls                               *bool   `yaml:"peer_auto_tls"                                  cli:"peer-auto-tls"`
+	SelfSignedCertValidity                    *int    `yaml:"self_signed_cert_validity"                      cli:"self-signed-cert-validity"`
+	PeerCrlFile                               *string `yaml:"peer_crl_file"                                  cli:"peer-crl-file"`
+	CipherSuites                              *string `yaml:"cipher_suites"                                  cli:"cipher-suites"`
+	Cors                                      *string `yaml:"cors"                                           cli:"cors"`
+	HostWhitelist                             *string `yaml:"host_whitelist"                                 cli:"host-whitelist"`
+	AuthToken                                 *string `yaml:"auth_token"                                     cli:"auth-token"`
+	BcryptCost                                *int    `yaml:"bcrypt_cost"                                    cli:"bcrypt-cost"`
+	AuthTokenTtl                              *int    `yaml:"auth_token_ttl"                                 cli:"auth-token-ttl"`
+	EnablePprof                               *bool   `yaml:"enable_pprof"                                   cli:"enable-pprof"`
+	Metrics                                   *string `yaml:"metrics"                                        cli:"metrics"`
+	ListenMetricsUrls                         *string `yaml:"listen_metrics_urls"                            cli:"listen-metrics-urls"`
+	Logger                                    *string `yaml:"logger"                                         cli:"logger"`
+	LogOutputs                                *string `yaml:"log_outputs"                                    cli:"log-outputs"`
+	LogLevel                                  *string `yaml:"log_level"                                      cli:"log-level"`
+	EnableLogRotation                         *bool   `yaml:"enable_log_rotation"                            cli:"enable-log-rotation"`
+	LogRotationConfigJson                     *string `yaml:"log_rotation_config_json"                       cli:"log-rotation-config-json"`
+	ExperimentalEnableDistributedTracing      *bool   `yaml:"experimental_enable_distributed_tracing"        cli:"experimental-enable-distributed-tracing"`
+	ExperimentalDistributedTracingAddress     *string `yaml:"experimental_distributed_tracing_address"       cli:"experimental-distributed-tracing-address"`
+	ExperimentalDistributedTracingServiceName *string `yaml:"experimental_distributed_tracing_service_name"  cli:"experimental-distributed-tracing-service-name"`
+	ExperimentalDistributedTracingInstanceId  *string `yaml:"experimental_distributed_tracing_instance_id"   cli:"experimental-distributed-tracing-instance-id"`
+	Proxy                                     *string `yaml:"proxy"                                          cli:"proxy"`
+	ProxyFailureWait                          *int    `yaml:"proxy_failure_wait"                             cli:"proxy-failure-wait"`
+	ProxyRefreshInterval                      *int    `yaml:"proxy_refresh_interval"                         cli:"proxy-refresh-interval"`
+	ProxyDialTimeout                          *int    `yaml:"proxy_dial_timeout"                             cli:"proxy-dial-timeout"`
+	ProxyWriteTimeout                         *int    `yaml:"proxy_write_timeout"                            cli:"proxy-write-timeout"`
+	ProxyReadTimeout                          *int    `yaml:"proxy_read_timeout"                             cli:"proxy-read-timeout"`
+	ExperimentalInitialCorruptCheck           *bool   `yaml:"experimental_initial_corrupt_check"             cli:"experimental-initial-corrupt-check"`
+	ExperimentalCorruptCheckTime              *string `yaml:"experimental_corrupt_check_time"                cli:"experimental-corrupt-check-time"`
+	ExperimentalEnableV2V3                    *string `yaml:"experimental_enable_v2v3"                       cli:"experimental-enable-v2v3"`
+	ExperimentalEnableLeaseCheckpoint         *bool   `yaml:"experimental_enable_lease_checkpoint"           cli:"experimental-enable-lease-checkpoint"`
+	ExperimentalCompactionBatchLimit          *int    `yaml:"experimental_compaction_batch_limit"            cli:"experimental-compaction-batch-limit"`
+	ExperimentalWatchProgressNotifyInterval   *string `yaml:"experimental_watch_progress_notify_interval"    cli:"experimental-watch-progress-notify-interval"`
+	ExperimentalWarningApplyDuration          *string `yaml:"experimental_warning_apply_duration"            cli:"experimental-warning-apply-duration"`
+	ExperimentalTxnModeWriteWithSharedBuffer  *bool   `yaml:"experimental_txn_mode_write_with_shared_buffer" cli:"experimental-txn-mode-write-with-shared-buffer"`
+	ForceNewCluster                           *bool   `yaml:"force_new_cluster"                              cli:"force-new-cluster"`
+	UnsafeNoFsync                             *bool   `yaml:"unsafe_no_fsync"                                cli:"unsafe-no-fsync"`
 }
 
 type Etcd2 struct {

--- a/config/types/etcd.go
+++ b/config/types/etcd.go
@@ -29,7 +29,7 @@ var (
 	EtcdMinorVersionTooNew = errors.New("Etcd minor version specified is too new, only options available in the previous minor version will be accepted")
 	EtcdMajorVersionTooNew = errors.New("Etcd version is not valid (too new)")
 	OldestEtcd             = *semver.New("2.3.0")
-	EtcdDefaultVersion     = *semver.New("3.0.0")
+	EtcdDefaultVersion     = *semver.New("3.5.0")
 )
 
 // Options can be the options for any Etcd version


### PR DESCRIPTION
# add support for etcd v3.4 and v3.5 options

The structs were generated by parsing `etcd --help` output and
processing using a go program that I wrote. The program is available
here: https://gist.github.com/jepio/11f447c4f6270e2a23f66d7fa414f3a6.

Related https://github.com/flatcar-linux/Flatcar/issues/398

## How to use

`make`

## Testing done
No warnings when deploying newer versions, and supports new options:
```
$ cat <<EOF | bin/ct
etcd:
  version: 3.5.1
  experimental_enable_distributed_tracing: true
EOF
{"ignition":{"config":{},"security":{"tls":{}},"timeouts":{},"version":"2.3.0"},"networkd":{},"passwd":{},"storage":{},"systemd":{"units":[{"dropins":[{"contents":"[Service]\nEnvironment=\"ETCD_IMAGE_TAG=v3.5.1\"\nExecStart=\nExecStart=/usr/lib/coreos/etcd-wrapper $ETCD_OPTS \\\n  --experimental-enable-distributed-tracing=true","name":"20-clct-etcd-member.conf"}],"enable":true,"name":"etcd-member.service"}]}}
```