### PR TITLE
config/types/update.go Added support for more fields in update section

### DIFF
--- a/config/types/update.go
+++ b/config/types/update.go
@@ -33,12 +33,20 @@ var (
 )
 
 type Update struct {
-	Group  UpdateGroup  `yaml:"group"`
-	Server UpdateServer `yaml:"server"`
+	Group            UpdateGroup            `yaml:"group"`
+	Server           UpdateServer           `yaml:"server"`
+	PCRPolicyServer  UpdatePCRPolicyServer  `yaml:"pcr_policy_server"`
+	DownloadUser     UpdateDownloadUser     `yaml:"download_user"`
+	DownloadPassword UpdateDownloadPassword `yaml:"download_password"`
+	MachineAlias     UpdateMachineAlias     `yaml:"machine_alias"`
 }
 
 type UpdateGroup string
 type UpdateServer string
+type UpdatePCRPolicyServer string
+type UpdateDownloadUser string
+type UpdateDownloadPassword string
+type UpdateMachineAlias string
 
 func (u Update) Validate() report.Report {
 	switch strings.ToLower(string(u.Group)) {
@@ -69,6 +77,18 @@ func init() {
 			}
 			if in.Update.Server != "" {
 				contents += fmt.Sprintf("\nSERVER=%s", in.Update.Server)
+			}
+			if in.Update.PCRPolicyServer != "" {
+				contents += fmt.Sprintf("\nPCR_POLICY_SERVER=%s", in.Update.PCRPolicyServer)
+			}
+			if in.Update.DownloadUser != "" {
+				contents += fmt.Sprintf("\nDOWNLOAD_USER=%s", in.Update.DownloadUser)
+			}
+			if in.Update.DownloadPassword != "" {
+				contents += fmt.Sprintf("\nDOWNLOAD_PASSWORD=%s", in.Update.DownloadPassword)
+			}
+			if in.Update.MachineAlias != "" {
+				contents += fmt.Sprintf("\nMACHINE_ALIAS=%s", in.Update.MachineAlias)
 			}
 		}
 		if in.Locksmith != nil {

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -160,6 +160,10 @@ _Note: all fields are optional unless otherwise marked_
 * **update**
     * **group** (string): the update group to follow. Most users will want one of: stable, beta, alpha.
     * **server** (string): the server to fetch updates from.
+    * **pcr_policy_server** (string): the server to receive posted TPM PCR policy from.
+    * **download_user** (string): the authentication user to fetch the update.
+    * **download_password** (string): the authentication password to fetch the update
+    * **machine_alias** (string): human readable machine alias to be displayed in the update server UI.
 * **locksmith**
     * **reboot_strategy** (string): the reboot strategy for locksmithd to follow. Must be one of: reboot, etcd-lock, off.
     * **window_start** (string, required if window-length isn't empty): the start of the window that locksmithd can reboot the machine during


### PR DESCRIPTION
The following fields are now supported by the update section:
* PCR_POLICY_SERVER
* DOWNLOAD_USER
* DOWNLOAD_PASSWORD
* MACHINE_ALIAS

also updated doc/configuration.md to reflect those changes.

Signed-off-by: Michael Heinzner <michael.heinzner@googlemail.com>

## How to use
 Execute `make` and execute the steps described in `Testing done`

## Testing done
Transpile the following config.yaml
```
update:
  download_user: michael
  download_password: password
  machine_alias: mymachine
  pcr_policy_server: some_nonsene
locksmith:
  reboot_strategy: reboot
  window_start: 09:00
  window_length: 1h
```
this was done with `./bin/ct <config.yaml  | jq .`

and checked the output for all the necessary fields
