### PR TITLE
Update dockerfile and add github action to publish docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Build docker image
+on:
+  push:
+    tags:
+    - v*
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: flatcar-linux/ct
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+
+    - name: Get tag name
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to registry
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64,linux/arm64/v8
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ COPY . .
 RUN apk update && apk add --virtual .build-deps bash git make \
     && make \
     && mv bin/ct /usr/bin/ \
-    && mv Dockerfile.build-alpine /tmp \
     && rm -rf $GOPATH \
     && apk del .build-deps && rm -rf /var/cache/apk
-WORKDIR /tmp
-ENTRYPOINT ["/usr/bin/ct"]
+
+FROM scratch
+COPY --from=0 /usr/bin/ct /ct
+ENTRYPOINT ["/ct"]

--- a/Dockerfile.build-alpine
+++ b/Dockerfile.build-alpine
@@ -1,3 +1,0 @@
-FROM alpine:3.7
-COPY /usr/bin/ct /ct
-ENTRYPOINT ["/ct"]

--- a/docker-build
+++ b/docker-build
@@ -2,7 +2,5 @@
 
 set -e
 VERSION=$(git describe)
-docker build -t $VERSION .
-docker run --rm --entrypoint tar $VERSION -c /usr/bin/ct Dockerfile.build-alpine \
-    | docker build -f Dockerfile.build-alpine --tag quay.io/coreos/ct:$VERSION -
-docker tag quay.io/coreos/ct:$VERSION quay.io/coreos/ct:latest-dev
+docker build --tag ghcr.io/flatcar-linux/ct:$VERSION .
+docker tag ghcr.io/flatcar-linux/ct:$VERSION ghcr.io/flatcar-linux/ct:latest-dev

--- a/docker-push
+++ b/docker-push
@@ -2,6 +2,5 @@
 
 set -e
 VERSION=$(git describe)
-docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD" quay.io
-docker push quay.io/coreos/ct:$VERSION
-docker push quay.io/coreos/ct:latest-dev
+docker push ghcr.io/flatcar-linux/ct:$VERSION
+docker push ghcr.io/flatcar-linux/ct:latest-dev


### PR DESCRIPTION
# Update dockerfile and add github action to publish docker images
The updated dockerfile uses the latest alpine tag, and the github action publishes multi-arch images for amd64 and arm64.

## How to use

Push a tag

## Testing done

Tested here: https://github.com/flatcar-linux/container-linux-config-transpiler/actions/runs/1933903152

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
