### PR TITLE
ci: pass version to Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,9 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Latest release gave the following:
```
podman run --rm ghcr.io/flatcar-linux/ct -version
ct
```

Instead of:
```
podman run --rm ct -version
ct v0.9.3
```

I think in the [CI](https://github.com/flatcar-linux/container-linux-config-transpiler/runs/5482728971?check_suite_focus=true), we can't rely on Git to get the tag: 
```
#10 2.710 fatal: No annotated tags can describe '3d9d6367d07de0323055e7d1536040e03b43c963'.
#10 2.710 However, there were unannotated tags: try --tags.
#10 2.713 fatal: No annotated tags can describe '3d9d6367d07de0323055e7d1536040e03b43c963'.
#10 2.713 However, there were unannotated tags: try --tags.
#10 2.716 fatal: No annotated tags can describe '3d9d6367d07de0323055e7d1536040e03b43c963'.
#10 2.716 However, there were unannotated tags: try --tags.
#10 2.719 fatal: No annotated tags can describe '3d9d6367d07de0323055e7d1536040e03b43c963'.
#10 2.719 However, there were unannotated tags: try --tags.
#10 2.801 fatal: No annotated tags can describe '3d9d6367d07de0323055e7d1536040e03b43c963'.
#10 2.801 However, there were unannotated tags: try --tags.
```

So let's try to explicitly pass the tag.